### PR TITLE
Use /usr/bin/ksh instead of /usr/bin/env

### DIFF
--- a/zabora/zabora.sh
+++ b/zabora/zabora.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env ksh
+#!/usr/bin/ksh
 rcode=0
 PATH=/usr/local/bin:${PATH}
 


### PR DESCRIPTION
Use /usr/bin/ksh instead of /usr/bin/env for modern systems